### PR TITLE
Do not install git-fame script for argopt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,9 +89,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=6", "pytest-cov", "pytest-timeout", "pytest-xdist"]
 
-[project.scripts]
-git-fame = "gitfame:main"
-
 [tool.flake8]
 max_line_length = 99
 extend_ignore = ["E261"]


### PR DESCRIPTION
I assume this wasn't intentional (argopt doesn't seem to depend on git-fame and creating the script here would create conflict with the git-fame package) and it's just a remnant of copy-pasting the pyproject.toml config from the git-fame project.