### PR TITLE
Exclude "examples" from installed packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ write_to_template = "__version__ = '{version}'\n"
 # version_file_template = "__version__ = '{version}'\n"
 
 [tool.setuptools.packages.find]
-exclude = ["tests"]
+exclude = ["tests", "examples"]
 
 [project.urls]
 repository = "https://github.com/casperdcl/argopt"


### PR DESCRIPTION
One more installation/packaging issue. I am not sure if this was intentional, but with 0.9 "examples" are now being installed directly into `site-packages/examples` which doesn't feel right to me (feel free to close this PR if this was intentional). If the examples should be shipped, I'd expect them to be installed to somewhere like `share/docs/argopt`.